### PR TITLE
unparse_path: remove unneeded include

### DIFF
--- a/src/unparse_path.c
+++ b/src/unparse_path.c
@@ -21,7 +21,6 @@
 /* For PRIx64 */
 #define __STDC_FORMAT_MACROS
 
-#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>


### PR DESCRIPTION
This fixes an invalid redefinition of wchar_t when compiling with hardened gcc-musl on gentoo. Note that I haven't tested this on other systems as I don't have access to any.