### PR TITLE
Restore activation error message in efibootmgr

### DIFF
--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -1625,7 +1625,7 @@ main(int argc, char **argv)
 		} else {
 			ret = set_active_state(prefices[mode]);
 			if (ret < 0)
-				error(16, "%s",
+				error(16,
 				  "Could not set active state for %s%04X",
 				  prefices[mode], opts.num);
 		}


### PR DESCRIPTION
As per issue #79, there appears to have been a minor glitch in the error output formatting due to the first `"%s"` element at the start of the error() function call. Originally, if a user attempted to set a state to active and an error occurred, the error message would appear as:

```
Could not set active state for %s%04X
```

After the change the message looks like the below, where condition is the current status; e.g. success, fail

```
Could not set active state for Boot0003: <condition>
```

On my system this appears to work now, but feel free to run your own tests.