### PR TITLE
Make gettext optional

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -1,4 +1,5 @@
 NAME	= efibootmgr
+NLS     = true
 prefix	?= /usr
 libdir	?= $(prefix)/lib64
 datadir	?= $(prefix)/share
@@ -14,6 +15,9 @@ override EXTRALIBDIR := $(foreach dir,$(EXTRALIBDIRS),-L$(dir))
 endif
 ifneq ($(origin EXTRAINCDIRS),undefined)
 override EXTRAINCDIR := $(foreach dir,$(EXTRAINCDIRS),-I$(dir))
+endif
+ifeq ($(NLS),true)
+nls_flags = -DHAVE_NLS
 endif
 
 EFIDIR	?= $(shell x=$$(which --skip-alias --skip-functions git 2>/dev/null) ; [ -n "$$x" ] && git config --get efibootmgr.efidir)
@@ -45,7 +49,7 @@ cflags	= $(EXTRALIBDIR) $(EXTRAINCDIR) $(CFLAGS) $(SUBDIR_CFLAGS) \
 	-DDEFAULT_LOADER=\"\\\\EFI\\\\$(EFIDIR)\\\\$(EFI_LOADER)\" \
 	$(if $(findstring clang,$(CC)),$(clang_cflags),) \
 	$(if $(findstring gcc,$(CC)),$(gcc_cflags),) \
-	$(call pkg-config-cflags)
+	$(call pkg-config-cflags) $(nls_flags)
 clang_ccldflags =
 gcc_ccldflags = -fno-merge-constants \
 	-Wl,--fatal-warnings,--no-allow-shlib-undefined \

--- a/src/efibootdump.c
+++ b/src/efibootdump.c
@@ -28,9 +28,11 @@
 
 int verbose;
 
-#define  _(String) gettext (String)
-#define Q_(String) dgettext (NULL, String)
-#define C_(Context,String) dgettext (Context,String)
+#if defined(HAVE_NLS)
+#define _(String) gettext (String)
+#else
+#define _(String) String
+#endif
 
 static void
 print_boot_entry(efi_load_option *loadopt, size_t data_size)

--- a/src/eficonman.c
+++ b/src/eficonman.c
@@ -21,9 +21,11 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#define  _(String) gettext (String)
-#define Q_(String) dgettext (NULL, String)
-#define C_(Context,String) dgettext (Context,String)
+#if defined(HAVE_NLS)
+#define _(String) gettext (String)
+#else
+#define _(String) String
+#endif
 
 /* ConIn-8be4df61-93ca-11d2-aa0d-00e098032b8c
  * ConInDev-8be4df61-93ca-11d2-aa0d-00e098032b8c


### PR DESCRIPTION
On some alternative libc, gettext functions are separated. Thus, it's also preferable to be able to disable those features.