### PR TITLE
Minor tweak to documentation (readmes and man page) to correct partition / mount order

### DIFF
--- a/README
+++ b/README
@@ -76,7 +76,7 @@ active), and the name displayed on the screen.
 Alternative use cases could be as follows:
 
 1) An OS installer would call 'efibootmgr -c'.  This assumes that
-   /boot/efi is your EFI System Partition, and is mounted at /dev/sda1.
+   /dev/sda1 is your EFI System Partition, and is mounted at /boot/efi.
    This creates a new boot option, called "Linux", and puts it at the top
    of the boot order list.  Options may be passed to modify the
    default behavior. The default OS Loader is elilo.efi.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ active), and the name displayed on the screen.
 Alternative use cases could be as follows:
 
 1) An OS installer would call `efibootmgr -c`.  This assumes that
-   /boot/efi is your EFI System Partition, and is mounted at /dev/sda1.
+   /dev/sda1 is your EFI System Partition, and is mounted at /boot/efi.
    This creates a new boot option, called "Linux", and puts it at the top
    of the boot order list.  Options may be passed to modify the
    default behavior. The default OS Loader is elilo.efi.

--- a/src/efibootmgr.8.in
+++ b/src/efibootmgr.8.in
@@ -167,8 +167,8 @@ flag (* means active) and the name displayed on the screen.
 .RE
 .SS "Creating a new boot option"
 An OS installer would call \fBefibootmgr -c\fR\&.
-This assumes that \fI/boot/efi\fR is your EFI System
-Partition, and is mounted at \fI/dev/sda1\fR\&. This
+This assumes that \fI/dev/sda1\fR is your EFI System
+Partition, and is mounted at \fI/boot/efi\fR\&. This
 creates a new boot option, called "Linux", and puts it at the top of
 the boot order list. Options may be passed to modify the default
 behavior. The default OS Loader is \fI@@DEFAULT_LOADER@@\fR\&.


### PR DESCRIPTION
Low priority, but this pull request resolve issue #111, so that both of the readme files and the man page reflect the correct order of the partition and mount, respectively.