### PR TITLE
fix normal behavior when force-reconnect option is not set

### DIFF
--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -1738,7 +1738,7 @@ main(int argc, char **argv)
 			mode = driver;
 	}
 
-	if (opts.reconnect && !opts.driver)
+	if (opts.reconnect > 0 && !opts.driver)
 		errorx(30, "--reconnect is supported only for driver entries.");
 
 	if (!efi_variables_supported())


### PR DESCRIPTION
Fixes https://github.com/rhboot/efibootmgr/issues/119 after https://github.com/rhboot/efibootmgr/pull/109

Runtime tested.

Before:
```
 efibootmgr -v
--reconnect is supported only for driver entries.
error trace:
```

After
```
 efibootmgr
BootCurrent: 0000
Timeout: 1 seconds
BootOrder: 0000,0004
Boot0000* kross HD(1,GPT,d2348ad4-09c1-bd48-99df-9894911c7023,0x800,0xfa000)/File(\EFI\kross\grubx64.efi)
Boot0004* UEFI: PXE IPV4 Realtek PCIe GBE Family Controller     PciRoot(0x0)/Pci(0x1,0x2)/Pci(0x0,0x2)/Pci(0x4,0x0)/Pci(0x0,0x0)/MAC(00d8610edd17,0)/IPv4(0.0.0.00.0.0.0,0,0)..BO
```