### PR TITLE
Android: correct the sources list

### DIFF
--- a/src/Android.mk
+++ b/src/Android.mk
@@ -28,6 +28,6 @@ LOCAL_CFLAGS := \
 LOCAL_SRC_FILES := \
 	efi.c \
 	efibootmgr.c \
-	unparse_path.c
+	parse_loader_data.c
 
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
Fixes: e8ce9fec ("Try a little harder on formatting known Loader Optional Data blobs")

Signed-off-by: Chih-Wei Huang <cwhuang@linux.org.tw>