### PR TITLE
remove-dupes: update error message

### DIFF
--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -1839,7 +1839,8 @@ main(int argc, char **argv)
 	if (opts.deduplicate) {
 		ret = remove_dupes_from_order(order_name[mode]);
 		if (ret)
-			error(9, "Could not set %s", order_name[mode]);
+			error(9, "Could not remove duplicates from %s order",
+			      order_name[mode]);
 	}
 
 	if (opts.delete_bootnext) {


### PR DESCRIPTION
The existing error message looks to be a copy and paste
from the set_order handler.  Replace the error message
with something related to the specified command.

Signed-off-by: Ryan Harper <ryan.harper@canonical.com>