### PR TITLE
Fix arg type in efidp_format_device_path calls.

### DIFF
--- a/src/efibootdump.c
+++ b/src/efibootdump.c
@@ -68,8 +68,7 @@ print_boot_entry(efi_load_option *loadopt, size_t data_size)
 	text_path = alloca(text_path_len);
 	if (!text_path)
 		error(100, "Couldn't allocate memory");
-	rc = efidp_format_device_path((unsigned char *)text_path,
-				      text_path_len, dp, pathlen);
+	rc = efidp_format_device_path(text_path, text_path_len, dp, pathlen);
 	if (rc < 0) {
 		printf("<bad device path>");
 		return;

--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -938,8 +938,7 @@ show_var_path(efi_load_option *load_option, size_t boot_data_size)
 	pathlen = efi_loadopt_pathlen(load_option,
 				      boot_data_size);
 	dp = efi_loadopt_path(load_option, boot_data_size);
-	rc = efidp_format_device_path((unsigned char *)text_path,
-				      text_path_len, dp, pathlen);
+	rc = efidp_format_device_path(text_path, text_path_len, dp, pathlen);
 	if (rc < 0) {
 		warning("Could not parse device path");
 		return;
@@ -953,8 +952,7 @@ show_var_path(efi_load_option *load_option, size_t boot_data_size)
 		return;
 	}
 
-	rc = efidp_format_device_path((unsigned char *)text_path,
-				      text_path_len, dp, pathlen);
+	rc = efidp_format_device_path(text_path, text_path_len, dp, pathlen);
 	if (rc >= 0) {
 		printf("\t%s", text_path);
 


### PR DESCRIPTION
The first `efidp_format_device_path` arg is defined as a `char*`, but several
call sites explicitly cast their argument to `unsigned char*`.  This commit
removes those casts.