### PR TITLE
Fix help message

### DIFF
--- a/README
+++ b/README
@@ -10,33 +10,33 @@ Note: efibootmgr requires that the kernel module efivars be loaded
 prior to use. Running 'modprobe efivars' should do the trick.
 
 usage: efibootmgr [options]
-        -a | --active          sets bootnum active
-        -A | --inactive        sets bootnum inactive
-        -b | --bootnum XXXX    modify BootXXXX (hex)
-        -B | --delete-bootnum  delete bootnum
-        -c | --create          create new variable bootnum and add to bootorder
-        -d | --disk disk       (defaults to /dev/sda) containing loader
-        -e | --edd [1|3|-1]    force EDD 1.0 or 3.0 creation variables, or guess
+        -a | --active          Sets bootnum active
+        -A | --inactive        Sets bootnum inactive
+        -b | --bootnum XXXX    Modify BootXXXX (hex)
+        -B | --delete-bootnum  Delete bootnum
+        -c | --create          Create new variable bootnum and add to bootorder
+        -d | --disk disk       (Defaults to /dev/sda) containing loader
+        -e | --edd [1|3|-1]    Force EDD 1.0 or 3.0 creation variables, or guess
         -E | --device num      EDD 1.0 device number (defaults to 0x80)
         -f | --reconnect       Re-connect devices after driver is loaded
         -F | --no-reconnect    Do not re-connect devices after driver is loaded
-        -g | --gpt             force disk w/ invalid PMBR to be treated as GPT
-        -i | --iface name      create a netboot entry for the named interface
-        -l | --loader name     (defaults to \elilo.efi)
+        -g | --gpt             Force disk w/ invalid PMBR to be treated as GPT
+        -i | --iface name      Create a netboot entry for the named interface
+        -l | --loader name     (Defaults to \elilo.efi)
         -L | --label label     Boot manager display label (defaults to "Linux")
-        -n | --bootnext XXXX   set BootNext to XXXX (hex)
-        -N | --delete-bootnext delete BootNext
-        -o | --bootorder XXXX,YYYY,ZZZZ,...     explicitly set BootOrder (hex)
-        -O | --delete-bootorder   delete BootOrder
-        -p | --part part          (defaults to 1) containing loader
-        -q | --quiet              be quiet
+        -n | --bootnext XXXX   Set BootNext to XXXX (hex)
+        -N | --delete-bootnext Delete BootNext
+        -o | --bootorder XXXX,YYYY,ZZZZ,...     Explicitly set BootOrder (hex)
+        -O | --delete-bootorder   Delete BootOrder
+        -p | --part part          (Defaults to 1) containing loader
+        -q | --quiet              Be quiet
         -t | --timeout seconds    Boot manager timeout
-        -T | --delete-timeout     delete Timeout value
-        -u | --unicode | --UCS-2  pass extra args as UCS-2 (default is ASCII)
-        -v | --verbose            print additional information
-        -V | --version            return version and exit
-        -w | --write-signature    write unique sig to MBR if needed
-        -@ | --append-binary-args append extra variable args from
+        -T | --delete-timeout     Delete Timeout value
+        -u | --unicode | --UCS-2  Pass extra args as UCS-2 (default is ASCII)
+        -v | --verbose            Print additional information
+        -V | --version            Return version and exit
+        -w | --write-signature    Write unique sig to MBR if needed
+        -@ | --append-binary-args Append extra variable args from
                                   file (use - to read from stdin).
 
 

--- a/README
+++ b/README
@@ -10,32 +10,32 @@ Note: efibootmgr requires that the kernel module efivars be loaded
 prior to use. Running 'modprobe efivars' should do the trick.
 
 usage: efibootmgr [options]
-        -a | --active          Sets bootnum active
-        -A | --inactive        Sets bootnum inactive
-        -b | --bootnum XXXX    Modify BootXXXX (hex)
-        -B | --delete-bootnum  Delete bootnum
-        -c | --create          Create new variable bootnum and add to bootorder
-        -d | --disk disk       (Defaults to /dev/sda) containing loader
-        -e | --edd [1|3|-1]    Force EDD 1.0 or 3.0 creation variables, or guess
-        -E | --device num      EDD 1.0 device number (defaults to 0x80)
-        -f | --reconnect       Re-connect devices after driver is loaded
-        -F | --no-reconnect    Do not re-connect devices after driver is loaded
-        -g | --gpt             Force disk w/ invalid PMBR to be treated as GPT
-        -i | --iface name      Create a netboot entry for the named interface
-        -l | --loader name     (Defaults to \elilo.efi)
-        -L | --label label     Boot manager display label (defaults to "Linux")
-        -n | --bootnext XXXX   Set BootNext to XXXX (hex)
-        -N | --delete-bootnext Delete BootNext
-        -o | --bootorder XXXX,YYYY,ZZZZ,...     Explicitly set BootOrder (hex)
-        -O | --delete-bootorder   Delete BootOrder
-        -p | --part part          (Defaults to 1) containing loader
-        -q | --quiet              Be quiet
-        -t | --timeout seconds    Boot manager timeout
-        -T | --delete-timeout     Delete Timeout value
-        -u | --unicode | --UCS-2  Pass extra args as UCS-2 (default is ASCII)
-        -v | --verbose            Print additional information
-        -V | --version            Return version and exit
-        -w | --write-signature    Write unique sig to MBR if needed
+        -a | --active          Sets bootnum active.
+        -A | --inactive        Sets bootnum inactive.
+        -b | --bootnum XXXX    Modify BootXXXX (hex).
+        -B | --delete-bootnum  Delete bootnum.
+        -c | --create          Create new variable bootnum and add to bootorder.
+        -d | --disk disk       (Defaults to /dev/sda) containing loader.
+        -e | --edd [1|3|-1]    Force EDD 1.0 or 3.0 creation variables, or guess.
+        -E | --device num      EDD 1.0 device number (defaults to 0x80).
+        -f | --reconnect       Re-connect devices after driver is loaded.
+        -F | --no-reconnect    Do not re-connect devices after driver is loaded.
+        -g | --gpt             Force disk w/ invalid PMBR to be treated as GPT.
+        -i | --iface name      Create a netboot entry for the named interface.
+        -l | --loader name     (Defaults to \elilo.efi).
+        -L | --label label     Boot manager display label (defaults to "Linux").
+        -n | --bootnext XXXX   Set BootNext to XXXX (hex).
+        -N | --delete-bootnext Delete BootNext.
+        -o | --bootorder XXXX,YYYY,ZZZZ,...     Explicitly set BootOrder (hex).
+        -O | --delete-bootorder   Delete BootOrder.
+        -p | --part part          (Defaults to 1) containing loader.
+        -q | --quiet              Be quiet.
+        -t | --timeout seconds    Boot manager timeout.
+        -T | --delete-timeout     Delete Timeout value.
+        -u | --unicode | --UCS-2  Pass extra args as UCS-2 (default is ASCII).
+        -v | --verbose            Print additional information.
+        -V | --version            Return version and exit.
+        -w | --write-signature    Write unique sig to MBR if needed.
         -@ | --append-binary-args Append extra variable args from
                                   file (use - to read from stdin).
 

--- a/README
+++ b/README
@@ -18,6 +18,8 @@ usage: efibootmgr [options]
         -d | --disk disk       (defaults to /dev/sda) containing loader
         -e | --edd [1|3|-1]    force EDD 1.0 or 3.0 creation variables, or guess
         -E | --device num      EDD 1.0 device number (defaults to 0x80)
+        -f | --reconnect       Re-connect devices after driver is loaded
+        -F | --no-reconnect    Do not re-connect devices after driver is loaded
         -g | --gpt             force disk w/ invalid PMBR to be treated as GPT
         -i | --iface name      create a netboot entry for the named interface
         -l | --loader name     (defaults to \elilo.efi)

--- a/README.md
+++ b/README.md
@@ -11,33 +11,33 @@ prior to use. Running `modprobe efivars` should do the trick.
 
 ```
 usage: efibootmgr [options]
-        -a | --active          sets bootnum active
-        -A | --inactive        sets bootnum inactive
-        -b | --bootnum XXXX    modify BootXXXX (hex)
-        -B | --delete-bootnum  delete bootnum
-        -c | --create          create new variable bootnum and add to bootorder
-        -d | --disk disk       (defaults to /dev/sda) containing loader
-        -e | --edd [1|3|-1]    force EDD 1.0 or 3.0 creation variables, or guess
+        -a | --active          Sets bootnum active
+        -A | --inactive        Sets bootnum inactive
+        -b | --bootnum XXXX    Modify BootXXXX (hex)
+        -B | --delete-bootnum  Delete bootnum
+        -c | --create          Create new variable bootnum and add to bootorder
+        -d | --disk disk       (Defaults to /dev/sda) containing loader
+        -e | --edd [1|3|-1]    Force EDD 1.0 or 3.0 creation variables, or guess
         -E | --device num      EDD 1.0 device number (defaults to 0x80)
         -f | --reconnect       Re-connect devices after driver is loaded
         -F | --no-reconnect    Do not re-connect devices after driver is loaded
-        -g | --gpt             force disk w/ invalid PMBR to be treated as GPT
-        -i | --iface name      create a netboot entry for the named interface
-        -l | --loader name     (defaults to \elilo.efi)
+        -g | --gpt             Force disk w/ invalid PMBR to be treated as GPT
+        -i | --iface name      Create a netboot entry for the named interface
+        -l | --loader name     (Defaults to \elilo.efi)
         -L | --label label     Boot manager display label (defaults to "Linux")
-        -n | --bootnext XXXX   set BootNext to XXXX (hex)
-        -N | --delete-bootnext delete BootNext
-        -o | --bootorder XXXX,YYYY,ZZZZ,...     explicitly set BootOrder (hex)
-        -O | --delete-bootorder   delete BootOrder
-        -p | --part part          (defaults to 1) containing loader
-        -q | --quiet              be quiet
+        -n | --bootnext XXXX   Set BootNext to XXXX (hex)
+        -N | --delete-bootnext Delete BootNext
+        -o | --bootorder XXXX,YYYY,ZZZZ,...     Explicitly set BootOrder (hex)
+        -O | --delete-bootorder   Delete BootOrder
+        -p | --part part          (Defaults to 1) containing loader
+        -q | --quiet              Be quiet
         -t | --timeout seconds    Boot manager timeout
-        -T | --delete-timeout     delete Timeout value
-        -u | --unicode | --UCS-2  pass extra args as UCS-2 (default is ASCII)
-        -v | --verbose            print additional information
-        -V | --version            return version and exit
-        -w | --write-signature    write unique sig to MBR if needed
-        -@ | --append-binary-args append extra variable args from
+        -T | --delete-timeout     Delete Timeout value
+        -u | --unicode | --UCS-2  Pass extra args as UCS-2 (default is ASCII)
+        -v | --verbose            Print additional information
+        -V | --version            Return version and exit
+        -w | --write-signature    Write unique sig to MBR if needed
+        -@ | --append-binary-args Append extra variable args from
                                   file (use - to read from stdin).
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,32 +11,32 @@ prior to use. Running `modprobe efivars` should do the trick.
 
 ```
 usage: efibootmgr [options]
-        -a | --active          Sets bootnum active
-        -A | --inactive        Sets bootnum inactive
-        -b | --bootnum XXXX    Modify BootXXXX (hex)
-        -B | --delete-bootnum  Delete bootnum
-        -c | --create          Create new variable bootnum and add to bootorder
-        -d | --disk disk       (Defaults to /dev/sda) containing loader
-        -e | --edd [1|3|-1]    Force EDD 1.0 or 3.0 creation variables, or guess
-        -E | --device num      EDD 1.0 device number (defaults to 0x80)
-        -f | --reconnect       Re-connect devices after driver is loaded
-        -F | --no-reconnect    Do not re-connect devices after driver is loaded
-        -g | --gpt             Force disk w/ invalid PMBR to be treated as GPT
-        -i | --iface name      Create a netboot entry for the named interface
-        -l | --loader name     (Defaults to \elilo.efi)
-        -L | --label label     Boot manager display label (defaults to "Linux")
-        -n | --bootnext XXXX   Set BootNext to XXXX (hex)
-        -N | --delete-bootnext Delete BootNext
-        -o | --bootorder XXXX,YYYY,ZZZZ,...     Explicitly set BootOrder (hex)
-        -O | --delete-bootorder   Delete BootOrder
-        -p | --part part          (Defaults to 1) containing loader
-        -q | --quiet              Be quiet
-        -t | --timeout seconds    Boot manager timeout
-        -T | --delete-timeout     Delete Timeout value
-        -u | --unicode | --UCS-2  Pass extra args as UCS-2 (default is ASCII)
-        -v | --verbose            Print additional information
-        -V | --version            Return version and exit
-        -w | --write-signature    Write unique sig to MBR if needed
+        -a | --active          Sets bootnum active.
+        -A | --inactive        Sets bootnum inactive.
+        -b | --bootnum XXXX    Modify BootXXXX (hex).
+        -B | --delete-bootnum  Delete bootnum.
+        -c | --create          Create new variable bootnum and add to bootorder.
+        -d | --disk disk       (Defaults to /dev/sda) containing loader.
+        -e | --edd [1|3|-1]    Force EDD 1.0 or 3.0 creation variables, or guess.
+        -E | --device num      EDD 1.0 device number (defaults to 0x80).
+        -f | --reconnect       Re-connect devices after driver is loaded.
+        -F | --no-reconnect    Do not re-connect devices after driver is loaded.
+        -g | --gpt             Force disk w/ invalid PMBR to be treated as GPT.
+        -i | --iface name      Create a netboot entry for the named interface.
+        -l | --loader name     (Defaults to \elilo.efi).
+        -L | --label label     Boot manager display label (defaults to "Linux").
+        -n | --bootnext XXXX   Set BootNext to XXXX (hex).
+        -N | --delete-bootnext Delete BootNext.
+        -o | --bootorder XXXX,YYYY,ZZZZ,...     Explicitly set BootOrder (hex).
+        -O | --delete-bootorder   Delete BootOrder.
+        -p | --part part          (Defaults to 1) containing loader.
+        -q | --quiet              Be quiet.
+        -t | --timeout seconds    Boot manager timeout.
+        -T | --delete-timeout     Delete Timeout value.
+        -u | --unicode | --UCS-2  Pass extra args as UCS-2 (default is ASCII).
+        -v | --verbose            Print additional information.
+        -V | --version            Return version and exit.
+        -w | --write-signature    Write unique sig to MBR if needed.
         -@ | --append-binary-args Append extra variable args from
                                   file (use - to read from stdin).
 ```

--- a/src/efibootmgr.8.in
+++ b/src/efibootmgr.8.in
@@ -26,26 +26,26 @@ non-volatile variables through
 The following is a list of options accepted by efibootmgr:
 .TP
 \fB-a | --active\fR
-Sets bootnum active
+Sets bootnum active.
 .TP
 \fB-A | --inactive\fR
-Sets bootnum inactive
+Sets bootnum inactive.
 .TP
 \fB-b | --bootnum \fIXXXX\fB\fR
-Modify Boot\fIXXXX\fR (hex)
+Modify Boot\fIXXXX\fR (hex).
 .TP
 \fB-B | --delete-bootnum\fR
-Delete bootnum
+Delete bootnum.
 .TP
 \fB-c | --create\fR
-Create new variable bootnum and add to bootorder
+Create new variable bootnum and add to bootorder.
 .TP
 \fB-d | --disk \fIDISK\fB\fR
 The disk containing the loader (defaults to
-\fI/dev/sda\fR)
+\fI/dev/sda\fR).
 .TP
 \fB-D | --remove-dups\fR
-Remove duplicated entries from BootOrder
+Remove duplicated entries from BootOrder.
 .TP
 \fB-e | --edd \fI1|3\fB\fR
 Force EDD 1.0 or 3.0 creation variables.
@@ -83,37 +83,37 @@ Re-connect devices after driver is loaded.  Only applicable for driver entries.
 Do not reconnect devices after driver is loaded.  Only applicable for driver entries.
 .TP
 \fB-g | --gpt\fR
-Force disk with invalid PMBR to be treated as GPT
+Force disk with invalid PMBR to be treated as GPT.
 .TP
 \fB-i | --iface \fINAME\fB\fR
-create a netboot entry for the named interface
+Create a netboot entry for the named interface.
 .TP
 \fB-l | --loader \fINAME\fB\fR
-Specify a loader (defaults to \fI@@DEFAULT_LOADER@@\fR)
+Specify a loader (defaults to \fI@@DEFAULT_LOADER@@\fR).
 .TP
 \fB-L | --label \fILABEL\fB\fR
-Boot manager display label (defaults to "Linux")
+Boot manager display label (defaults to "Linux").
 .TP
 \fB-m | --mirror-below-4G \fIt|f\fB\fR
-Set t if you want to mirror memory below 4GB
+Set t if you want to mirror memory below 4GB.
 .TP
 \fB-M | --mirror-above-4G \fIX\fB\fR
 X percentage memory to mirror above 4GB. Floating-point value with up to 2 decimal places is accepted.
 .TP
 \fB-n | --bootnext \fIXXXX\fB\fR
-Set BootNext to XXXX (hex)
+Set BootNext to XXXX (hex).
 .TP
 \fB-N | --delete-bootnext\fR
-Delete BootNext
+Delete BootNext.
 .TP
 \fB-o | --bootorder \fIXXXX\fB,\fIYYYY\fB,\fIZZZZ\fB\fR
 Explicitly set BootOrder (hex). Any value from 0 to FFFF is accepted so long as it corresponds to an existing Boot#### variable, and zero padding is not required.
 .TP
 \fB-O | --delete-bootorder\fR
-Delete BootOrder
+Delete BootOrder.
 .TP
 \fB-p | --part \fIPART\fB\fR
-Partition number containing the bootloader (defaults to 1)
+Partition number containing the bootloader (defaults to 1).
 .TP
 \fB-q | --quiet\fR
 Quiet mode - supresses output.
@@ -129,22 +129,22 @@ Delete Timeout variable.
 .TP
 \fB-u | --unicode | --UCS-2 \fR
 Handle extra command line arguments as UCS-2 (default is
-ASCII)
+ASCII).
 .TP
 \fB-v | --verbose\fR
-Verbose mode - prints additional information
+Verbose mode - prints additional information.
 .TP
 \fB-V | --version\fR
 Just print version string and exit.
 .TP
 \fB-w | --write-signature\fR
-write unique signature to the MBR if needed
+Write unique signature to the MBR if needed.
 .TP
 \fB-y | --sysprep\fR
 Operate on SysPrep#### variables instead of Boot#### variables.
 .TP
 \fB-@ | --append-binary-args \fR
-append extra variable args from file (use - to read
+Append extra variable args from file (use - to read
 from stdin). Data in file is appended as command line
 arguments to the boot loader command, with no modification to
 the data, so you can pass any binary or text data necessary.

--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -1350,22 +1350,22 @@ usage()
 {
 	printf("efibootmgr version %s\n", EFIBOOTMGR_VERSION);
 	printf("usage: efibootmgr [options]\n");
-	printf("\t-a | --active         sets bootnum active\n");
-	printf("\t-A | --inactive       sets bootnum inactive\n");
-	printf("\t-b | --bootnum XXXX   modify BootXXXX (hex)\n");
-	printf("\t-B | --delete-bootnum delete bootnum\n");
-	printf("\t-c | --create         create new variable bootnum and add to bootorder\n");
-	printf("\t-C | --create-only    create new variable bootnum and do not add to bootorder\n");
+	printf("\t-a | --active         Sets bootnum active\n");
+	printf("\t-A | --inactive       Sets bootnum inactive\n");
+	printf("\t-b | --bootnum XXXX   Modify BootXXXX (hex)\n");
+	printf("\t-B | --delete-bootnum Delete bootnum\n");
+	printf("\t-c | --create         Create new variable bootnum and add to bootorder\n");
+	printf("\t-C | --create-only    Create new variable bootnum and do not add to bootorder\n");
 	printf("\t-d | --disk disk      Disk containing boot loader (defaults to /dev/sda)\n");
-	printf("\t-D | --remove-dups    remove duplicate values from BootOrder\n");
-	printf("\t-e | --edd [1|3]      force boot entries to be created using EDD 1.0 or 3.0 info\n");
+	printf("\t-D | --remove-dups    Remove duplicate values from BootOrder\n");
+	printf("\t-e | --edd [1|3]      Force boot entries to be created using EDD 1.0 or 3.0 info\n");
 	printf("\t-E | --device num     EDD 1.0 device number (defaults to 0x80)\n");
 	printf("\t     --full-dev-path  Use a full device path\n");
 	printf("\t     --file-dev-path  Use an abbreviated File() device path\n");
 	printf("\t-f | --reconnect      Re-connect devices after driver is loaded\n");
 	printf("\t-F | --no-reconnect   Do not re-connect devices after driver is loaded\n");
-	printf("\t-g | --gpt            force disk with invalid PMBR to be treated as GPT\n");
-	printf("\t-i | --iface name     create a netboot entry for the named interface\n");
+	printf("\t-g | --gpt            Force disk with invalid PMBR to be treated as GPT\n");
+	printf("\t-i | --iface name     Create a netboot entry for the named interface\n");
 #if 0
 	printf("\t     --ip-addr <local>,<remote>	set local and remote IP addresses\n");
 	printf("\t     --ip-gateway <gateway>	set the network gateway\n");
@@ -1374,26 +1374,26 @@ usage()
 	printf("\t     --ip-port <local>,<remote>	set local and remote IP ports\n");
 	printf("\t     --ip-origin { {dhcp|static} | { static|stateless|stateful} }\n");
 #endif
-	printf("\t-l | --loader name     (defaults to \""DEFAULT_LOADER"\")\n");
+	printf("\t-l | --loader name     (Defaults to \""DEFAULT_LOADER"\")\n");
 	printf("\t-L | --label label     Boot manager display label (defaults to \"Linux\")\n");
-	printf("\t-m | --mirror-below-4G t|f mirror memory below 4GB\n");
-	printf("\t-M | --mirror-above-4G X percentage memory to mirror above 4GB\n");
-	printf("\t-n | --bootnext XXXX   set BootNext to XXXX (hex)\n");
-	printf("\t-N | --delete-bootnext delete BootNext\n");
-	printf("\t-o | --bootorder XXXX,YYYY,ZZZZ,...     explicitly set BootOrder (hex)\n");
-	printf("\t-O | --delete-bootorder delete BootOrder\n");
-	printf("\t-p | --part part        partition containing loader (defaults to 1 on partitioned devices)\n");
-	printf("\t-q | --quiet            be quiet\n");
+	printf("\t-m | --mirror-below-4G t|f Mirror memory below 4GB\n");
+	printf("\t-M | --mirror-above-4G X Percentage memory to mirror above 4GB\n");
+	printf("\t-n | --bootnext XXXX   Set BootNext to XXXX (hex)\n");
+	printf("\t-N | --delete-bootnext Delete BootNext\n");
+	printf("\t-o | --bootorder XXXX,YYYY,ZZZZ,...     Explicitly set BootOrder (hex)\n");
+	printf("\t-O | --delete-bootorder Delete BootOrder\n");
+	printf("\t-p | --part part        Partition containing loader (defaults to 1 on partitioned devices)\n");
+	printf("\t-q | --quiet            Be quiet\n");
 	printf("\t-r | --driver           Operate on Driver variables, not Boot Variables\n");
-	printf("\t-t | --timeout seconds  set boot manager timeout waiting for user input.\n");
-	printf("\t-T | --delete-timeout   delete Timeout.\n");
-	printf("\t-u | --unicode | --UCS-2  handle extra args as UCS-2 (default is ASCII)\n");
-	printf("\t-v | --verbose          print additional information\n");
-	printf("\t-V | --version          return version and exit\n");
-	printf("\t-w | --write-signature  write unique sig to MBR if needed\n");
+	printf("\t-t | --timeout seconds  Set boot manager timeout waiting for user input.\n");
+	printf("\t-T | --delete-timeout   Delete Timeout.\n");
+	printf("\t-u | --unicode | --UCS-2  Handle extra args as UCS-2 (default is ASCII)\n");
+	printf("\t-v | --verbose          Print additional information\n");
+	printf("\t-V | --version          Return version and exit\n");
+	printf("\t-w | --write-signature  Write unique sig to MBR if needed\n");
 	printf("\t-y | --sysprep          Operate on SysPrep variables, not Boot Variables.\n");
-	printf("\t-@ | --append-binary-args file  append extra args from file (use \"-\" for stdin)\n");
-	printf("\t-h | --help             show help/usage\n");
+	printf("\t-@ | --append-binary-args file  Append extra args from file (use \"-\" for stdin)\n");
+	printf("\t-h | --help             Show help/usage\n");
 }
 
 static void

--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -1350,22 +1350,22 @@ usage()
 {
 	printf("efibootmgr version %s\n", EFIBOOTMGR_VERSION);
 	printf("usage: efibootmgr [options]\n");
-	printf("\t-a | --active         Sets bootnum active\n");
-	printf("\t-A | --inactive       Sets bootnum inactive\n");
-	printf("\t-b | --bootnum XXXX   Modify BootXXXX (hex)\n");
-	printf("\t-B | --delete-bootnum Delete bootnum\n");
-	printf("\t-c | --create         Create new variable bootnum and add to bootorder\n");
-	printf("\t-C | --create-only    Create new variable bootnum and do not add to bootorder\n");
-	printf("\t-d | --disk disk      Disk containing boot loader (defaults to /dev/sda)\n");
-	printf("\t-D | --remove-dups    Remove duplicate values from BootOrder\n");
-	printf("\t-e | --edd [1|3]      Force boot entries to be created using EDD 1.0 or 3.0 info\n");
-	printf("\t-E | --device num     EDD 1.0 device number (defaults to 0x80)\n");
-	printf("\t     --full-dev-path  Use a full device path\n");
-	printf("\t     --file-dev-path  Use an abbreviated File() device path\n");
-	printf("\t-f | --reconnect      Re-connect devices after driver is loaded\n");
-	printf("\t-F | --no-reconnect   Do not re-connect devices after driver is loaded\n");
-	printf("\t-g | --gpt            Force disk with invalid PMBR to be treated as GPT\n");
-	printf("\t-i | --iface name     Create a netboot entry for the named interface\n");
+	printf("\t-a | --active         Sets bootnum active.\n");
+	printf("\t-A | --inactive       Sets bootnum inactive.\n");
+	printf("\t-b | --bootnum XXXX   Modify BootXXXX (hex).\n");
+	printf("\t-B | --delete-bootnum Delete bootnum.\n");
+	printf("\t-c | --create         Create new variable bootnum and add to bootorder.\n");
+	printf("\t-C | --create-only    Create new variable bootnum and do not add to bootorder.\n");
+	printf("\t-d | --disk disk      Disk containing boot loader (defaults to /dev/sda).\n");
+	printf("\t-D | --remove-dups    Remove duplicate values from BootOrder.\n");
+	printf("\t-e | --edd [1|3]      Force boot entries to be created using EDD 1.0 or 3.0 info.\n");
+	printf("\t-E | --device num     EDD 1.0 device number (defaults to 0x80).\n");
+	printf("\t     --full-dev-path  Use a full device path.\n");
+	printf("\t     --file-dev-path  Use an abbreviated File() device path.\n");
+	printf("\t-f | --reconnect      Re-connect devices after driver is loaded.\n");
+	printf("\t-F | --no-reconnect   Do not re-connect devices after driver is loaded.\n");
+	printf("\t-g | --gpt            Force disk with invalid PMBR to be treated as GPT.\n");
+	printf("\t-i | --iface name     Create a netboot entry for the named interface.\n");
 #if 0
 	printf("\t     --ip-addr <local>,<remote>	set local and remote IP addresses\n");
 	printf("\t     --ip-gateway <gateway>	set the network gateway\n");
@@ -1374,26 +1374,26 @@ usage()
 	printf("\t     --ip-port <local>,<remote>	set local and remote IP ports\n");
 	printf("\t     --ip-origin { {dhcp|static} | { static|stateless|stateful} }\n");
 #endif
-	printf("\t-l | --loader name     (Defaults to \""DEFAULT_LOADER"\")\n");
-	printf("\t-L | --label label     Boot manager display label (defaults to \"Linux\")\n");
-	printf("\t-m | --mirror-below-4G t|f Mirror memory below 4GB\n");
-	printf("\t-M | --mirror-above-4G X Percentage memory to mirror above 4GB\n");
-	printf("\t-n | --bootnext XXXX   Set BootNext to XXXX (hex)\n");
-	printf("\t-N | --delete-bootnext Delete BootNext\n");
-	printf("\t-o | --bootorder XXXX,YYYY,ZZZZ,...     Explicitly set BootOrder (hex)\n");
-	printf("\t-O | --delete-bootorder Delete BootOrder\n");
-	printf("\t-p | --part part        Partition containing loader (defaults to 1 on partitioned devices)\n");
-	printf("\t-q | --quiet            Be quiet\n");
-	printf("\t-r | --driver           Operate on Driver variables, not Boot Variables\n");
+	printf("\t-l | --loader name     (Defaults to \""DEFAULT_LOADER"\").\n");
+	printf("\t-L | --label label     Boot manager display label (defaults to \"Linux\").\n");
+	printf("\t-m | --mirror-below-4G t|f Mirror memory below 4GB.\n");
+	printf("\t-M | --mirror-above-4G X Percentage memory to mirror above 4GB.\n");
+	printf("\t-n | --bootnext XXXX   Set BootNext to XXXX (hex).\n");
+	printf("\t-N | --delete-bootnext Delete BootNext.\n");
+	printf("\t-o | --bootorder XXXX,YYYY,ZZZZ,...     Explicitly set BootOrder (hex).\n");
+	printf("\t-O | --delete-bootorder Delete BootOrder.\n");
+	printf("\t-p | --part part        Partition containing loader (defaults to 1 on partitioned devices).\n");
+	printf("\t-q | --quiet            Be quiet.\n");
+	printf("\t-r | --driver           Operate on Driver variables, not Boot Variables.\n");
 	printf("\t-t | --timeout seconds  Set boot manager timeout waiting for user input.\n");
 	printf("\t-T | --delete-timeout   Delete Timeout.\n");
-	printf("\t-u | --unicode | --UCS-2  Handle extra args as UCS-2 (default is ASCII)\n");
-	printf("\t-v | --verbose          Print additional information\n");
-	printf("\t-V | --version          Return version and exit\n");
-	printf("\t-w | --write-signature  Write unique sig to MBR if needed\n");
+	printf("\t-u | --unicode | --UCS-2  Handle extra args as UCS-2 (default is ASCII).\n");
+	printf("\t-v | --verbose          Print additional information.\n");
+	printf("\t-V | --version          Return version and exit.\n");
+	printf("\t-w | --write-signature  Write unique sig to MBR if needed.\n");
 	printf("\t-y | --sysprep          Operate on SysPrep variables, not Boot Variables.\n");
-	printf("\t-@ | --append-binary-args file  Append extra args from file (use \"-\" for stdin)\n");
-	printf("\t-h | --help             Show help/usage\n");
+	printf("\t-@ | --append-binary-args file  Append extra args from file (use \"-\" for stdin).\n");
+	printf("\t-h | --help             Show help/usage.\n");
 }
 
 static void


### PR DESCRIPTION
This pull request contains following changes:

- Add missing -f/-F option in README.
- Start first letter of help message with a capital letter and end with a period punctuation to make things consistent with other option messages.

/cc @vathpela 