### PR TITLE
README: Note efivarfs as the current required kernel module

### DIFF
--- a/README
+++ b/README
@@ -6,8 +6,8 @@ the next running boot option, and more.
 Details on the EFI Boot Manager are available from the EFI
 Specification, v1.02 or above, available from: http://www.uefi.org
 
-Note: efibootmgr requires that the kernel module efivars be loaded
-prior to use. Running 'modprobe efivars' should do the trick.
+Note: efibootmgr requires either the efivarfs or the
+legacy efivars kernel module to be loaded prior to use.
 
 usage: efibootmgr [options]
         -a | --active          sets bootnum active

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ the next running boot option, and more.
 Details on the EFI Boot Manager are available from the EFI
 Specification, v1.02 or above, available from: http://www.uefi.org
 
-Note: efibootmgr requires that the kernel module efivars be loaded
-prior to use. Running `modprobe efivars` should do the trick.
+Note: efibootmgr requires either the efivarfs or the
+legacy efivars kernel module to be loaded prior to use.
 
 ```
 usage: efibootmgr [options]


### PR DESCRIPTION
efivars is now deprecated and only available on x86 and IA-64 [1].

Drop mention of modprobe, probably not needed on the average system and
advanced users will know what to do.

[1]
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=963fabf37f6a

Signed-off-by: Chris Mayo <aklhfex@gmail.com>