### PR TITLE
Implement --uri option for use with --ifname

### DIFF
--- a/efibootmgr.spec.in
+++ b/efibootmgr.spec.in
@@ -6,7 +6,7 @@ Group: System Environment/Base
 License: GPLv2+
 URL: https://github.com/rhboot/%{name}/
 BuildRequires: git, popt-devel
-BuildRequires: efivar-libs >= 30-1, efivar-devel >= 30-1
+BuildRequires: efivar-libs >= 39-1, efivar-devel >= 39-1
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXXXX)
 # EFI/UEFI don't exist on PPC
 ExclusiveArch: %{ix86} x86_64 aarch64 arm

--- a/src/efi.c
+++ b/src/efi.c
@@ -174,37 +174,40 @@ make_linux_load_option(uint8_t **data, size_t *data_size,
 	efidp dp = NULL;
 
 	if (opts.iface && opts.ip_version == EFIBOOTMGR_IPV4) {
-		needed = efi_generate_ipv4_device_path(NULL, 0, opts.iface,
-						       opts.local_ip_addr,
-						       opts.remote_ip_addr,
-						       opts.gateway_ip_addr,
-						       opts.ip_netmask,
-						       opts.ip_local_port,
-						       opts.ip_remote_port,
-						       opts.ip_protocol,
-						       opts.ip_addr_origin);
+		needed = efi_generate_ipv4_device_path_with_uri(
+					NULL, 0, opts.iface,
+					opts.local_ip_addr,
+					opts.remote_ip_addr,
+					opts.gateway_ip_addr,
+					opts.ip_netmask,
+					opts.ip_local_port,
+					opts.ip_remote_port,
+					opts.ip_protocol,
+					opts.ip_addr_origin,
+					opts.uri);
 		if (needed < 0) {
-			efi_error("efi_generate_ipv4_device_path() = %zd (failed)",
+			efi_error("efi_generate_ipv4_device_path_with_uri() = %zd (failed)",
 					needed);
 			return -1;
 		}
 		if (data_size && *data_size) {
 			dp = malloc(needed);
 
-			needed = efi_generate_ipv4_device_path(
-							(uint8_t *)dp, needed,
-							opts.iface,
-							opts.local_ip_addr,
-							opts.remote_ip_addr,
-							opts.gateway_ip_addr,
-							opts.ip_netmask,
-							opts.ip_local_port,
-							opts.ip_remote_port,
-							opts.ip_protocol,
-							opts.ip_addr_origin);
+			needed = efi_generate_ipv4_device_path_with_uri(
+					(uint8_t *)dp, needed,
+					opts.iface,
+					opts.local_ip_addr,
+					opts.remote_ip_addr,
+					opts.gateway_ip_addr,
+					opts.ip_netmask,
+					opts.ip_local_port,
+					opts.ip_remote_port,
+					opts.ip_protocol,
+					opts.ip_addr_origin,
+					opts.uri);
 			if (needed < 0) {
 				free(dp);
-				efi_error("efi_generate_ipv4_device_path() = %zd (failed)",
+				efi_error("efi_generate_ipv4_device_path_with_uri() = %zd (failed)",
 						needed);
 				return -1;
 			}

--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -1409,8 +1409,9 @@ usage()
 	printf("\t-f | --reconnect      Re-connect devices after driver is loaded.\n");
 	printf("\t-F | --no-reconnect   Do not re-connect devices after driver is loaded.\n");
 	printf("\t-g | --gpt            Force disk with invalid PMBR to be treated as GPT.\n");
-	printf("\t-i | --iface name     Create a netboot entry for the named interface.\n");
+	printf("\t-i | --iface name     Create a netboot entry for the named interface (IPv4+DHCP support only).\n");
 	printf("\t-I | --index number   When creating an entry, insert it in bootorder at specified position (default: 0).\n");
+	printf("\t     --uri Uri        Specify an Uri (for use with --iface option).\n");
 	printf("\t-l | --loader name     (Defaults to \""DEFAULT_LOADER"\").\n");
 	printf("\t-L | --label label     Boot manager display label (defaults to \"Linux\").\n");
 	printf("\t-m | --mirror-below-4G t|f Mirror memory below 4GB.\n");
@@ -1482,6 +1483,7 @@ parse_opts(int argc, char **argv)
 			{"gpt",                    no_argument, 0, 'g'},
 			{"iface",            required_argument, 0, 'i'},
 			{"index",            required_argument, 0, 'I'},
+			{"uri",	             required_argument, 0, 0},
 			{"keep",                   no_argument, 0, 'k'},
 			{"loader",           required_argument, 0, 'l'},
 			{"label",            required_argument, 0, 'L'},
@@ -1770,6 +1772,8 @@ parse_opts(int argc, char **argv)
 				    opts.abbreviate_path != EFIBOOTMGR_PATH_ABBREV_FILE)
 					errx(41, "contradicting --full-dev-path/--file-dev-path/-e options");
 				opts.abbreviate_path = EFIBOOTMGR_PATH_ABBREV_FILE;
+			} else if (!strcmp(long_options[option_index].name, "uri")) {
+				opts.uri = optarg;
 			} else {
 				usage();
 				exit(1);
@@ -1811,6 +1815,9 @@ main(int argc, char **argv)
 	}
 
 	verbose = opts.verbose;
+
+	if (opts.uri && !opts.iface)
+		errx(25, "--uri is supported only with --iface option.");
 
 	if (opts.sysprep && opts.driver)
 		errx(25, "--sysprep and --driver may not be used together.");

--- a/src/include/efibootmgr.h
+++ b/src/include/efibootmgr.h
@@ -59,6 +59,7 @@ typedef struct {
 	uint16_t ip_remote_port;
 	uint16_t ip_protocol;
 	uint8_t ip_addr_origin;
+	char *uri;
 
 	char *loader;
 	unsigned char *label;


### PR DESCRIPTION
New `--uri` option enables to specify a URI when creating a network boot entry.
This requires support in **libefiboot**, which is provided by version 39 (PR https://github.com/rhboot/efivar/pull/217).