### PR TITLE
efibootdump: fopen: use 'e' to set O_CLOEXEC

### DIFF
--- a/src/efibootdump.c
+++ b/src/efibootdump.c
@@ -227,7 +227,7 @@ main(int argc, char *argv[])
 		if (data == NULL)
 			error(8, "Could not allocate memory");
 
-		f = fopen(filename, "r");
+		f = fopen(filename, "re");
 		if (!f)
 			error(9, "Could not open \"%s\"", filename);
 


### PR DESCRIPTION
```
src/efibootdump.c:230:23: warning: use 'fopen' mode 'e' to set O_CLOEXEC [android-cloexec-fopen]
                f = fopen(filename, "r");
                                    ^~~
                                    "re"
```