### PR TITLE
Definitions in optimized code

### DIFF
--- a/src/efibootdump.c
+++ b/src/efibootdump.c
@@ -45,7 +45,7 @@ print_boot_entry(efi_load_option *loadopt, size_t data_size)
 	size_t raw_len;
 
 	ssize_t rc;
-	efidp dp = NULL;
+	efidp dp;
 
 	printf("%c ", (efi_loadopt_attrs(loadopt) & LOAD_OPTION_ACTIVE)
 	              ? '*' : ' ');

--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -352,7 +352,7 @@ static int
 read_order(const char *name, var_entry_t **order)
 {
 	int rc;
-	var_entry_t *new = NULL, *bo = NULL;
+	var_entry_t *new = NULL, *bo;
 
 	if (*order == NULL) {
 		new = calloc(1, sizeof (**order));

--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -161,7 +161,7 @@ free_array(char **array)
 static int
 compare(const void *a, const void *b)
 {
-	int rc = -1;
+	int rc;
 	uint16_t n1, n2;
 	memcpy(&n1, a, sizeof(n1));
 	memcpy(&n2, b, sizeof(n2));


### PR DESCRIPTION
Some variables are assigned first and then used, usually without initializing them, you can omit some execution instructions, such as mov.
