### PR TITLE
get_entry: return entry if it was found before reaching the end of the list

### DIFF
--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -1192,6 +1192,7 @@ get_entry(list_t *entries, uint16_t num)
 			entry = NULL;
 			continue;
 		}
+		return entry;
 	}
 
 	return entry;


### PR DESCRIPTION
Fix for get_entry function. It was working only if the provided num matched the last entry in the list. 

For all the others it returned null. 

After the fix it works correctly, (allowing setting active status etc. of all entries).