### PR TITLE
Fix insertion location on certain index

### DIFF
--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -420,8 +420,8 @@ add_to_order(const char *name, uint16_t num, uint16_t insert_at)
 		return -1;
 
 	if (insert_at != 0) {
-		if (insert_at > order->data_size)
-			insert_at = order->data_size;
+		if (insert_at * sizeof(uint16_t) > order->data_size)
+			insert_at = order->data_size / sizeof(uint16_t);
 		memcpy(new_data, old_data, insert_at * sizeof(uint16_t));
 	}
 	new_data[insert_at] = num;

--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -1509,7 +1509,7 @@ parse_opts(int argc, char **argv)
 		};
 
 		c = getopt_long(argc, argv,
-				"aAb:BcCd:De:E:fFgi:kl:L:m:M:n:No:Op:qrt:Tuv::Vwy@:h",
+				"aAb:BcCd:De:E:fFgi:I:kl:L:m:M:n:No:Op:qrt:Tuv::Vwy@:h",
 				long_options, &option_index);
 		if (c == -1)
 			break;


### PR DESCRIPTION
I've found the following issues with adding boot entries at particular index, this pull request fixes both of them:

1. Short index option (-I) isn't recognized. 
Using short option like this:
`> sudo efibootmgr -c -d /dev/sda -p 1 -I 2`
return the following error:
`efibootmgr: invalid option -- 'I'`

2. In some cases using `--index` causes segmentation fault.
This happens when the passed index  is greater than current boot order size. Size of the order entry size (uint16_t) hasn't been taken into account in all places.
