### PR TITLE
Remove the --write-signature support

### DIFF
--- a/README
+++ b/README
@@ -35,7 +35,6 @@ usage: efibootmgr [options]
         -u | --unicode | --UCS-2  Pass extra args as UCS-2 (default is ASCII).
         -v | --verbose            Print additional information.
         -V | --version            Return version and exit.
-        -w | --write-signature    Write unique sig to MBR if needed.
         -@ | --append-binary-args Append extra variable args from
                                   file (use - to read from stdin).
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ usage: efibootmgr [options]
         -u | --unicode | --UCS-2  Pass extra args as UCS-2 (default is ASCII).
         -v | --verbose            Print additional information.
         -V | --version            Return version and exit.
-        -w | --write-signature    Write unique sig to MBR if needed.
         -@ | --append-binary-args Append extra variable args from
                                   file (use - to read from stdin).
 ```

--- a/src/efibootmgr.8.in
+++ b/src/efibootmgr.8.in
@@ -4,7 +4,7 @@
 efibootmgr \- change the UEFI Boot Manager configuration
 .SH SYNOPSIS
 
-\fBefibootmgr\fR [ \fB-a\fR ] [ \fB-A\fR ] [ \fB-b \fIXXXX\fB\fR ] [ \fB-B\fR ] [ \fB-c\fR ] [ \fB-d \fIDISK\fB\fR ] [ \fB-D\fR ] [ \fB-e \fI1|3|-1\fB\fR ] [ \fB-E \fINUM\fB\fR ] [ \fB--full-dev-path\fR | \fB--file-dev-path\fR ] [ \fB-f\fR ] [ \fB-F\fR ] [ \fB-g\fR ] [ \fB-i \fINAME\fB\fR ] [ \fB-l \fINAME\fB\fR ] [ \fB-L \fILABEL\fB\fR ] [ \fB-m \fIt|f\fB\fR ] [ \fB-M \fIX\fB\fR ] [ \fB-n \fIXXXX\fB\fR ] [ \fB-N\fR ] [ \fB-o \fIXXXX\fB,\fIYYYY\fB,\fIZZZZ\fB\fR\fI ...\fR ] [ \fB-O\fR ] [ \fB-p \fIPART\fB\fR ] [ \fB-q\fR ] [ \fB-r\fR | \fB-y\fR ] [ \fB-t \fIseconds\fB\fR ] [ \fB-T\fR ] [ \fB-u\fR ] [ \fB-v\fR ] [ \fB-V\fR ] [ \fB-w\fR ] [ \fB-@ \fIfile\fB\fR ]
+\fBefibootmgr\fR [ \fB-a\fR ] [ \fB-A\fR ] [ \fB-b \fIXXXX\fB\fR ] [ \fB-B\fR ] [ \fB-c\fR ] [ \fB-d \fIDISK\fB\fR ] [ \fB-D\fR ] [ \fB-e \fI1|3|-1\fB\fR ] [ \fB-E \fINUM\fB\fR ] [ \fB--full-dev-path\fR | \fB--file-dev-path\fR ] [ \fB-f\fR ] [ \fB-F\fR ] [ \fB-g\fR ] [ \fB-i \fINAME\fB\fR ] [ \fB-l \fINAME\fB\fR ] [ \fB-L \fILABEL\fB\fR ] [ \fB-m \fIt|f\fB\fR ] [ \fB-M \fIX\fB\fR ] [ \fB-n \fIXXXX\fB\fR ] [ \fB-N\fR ] [ \fB-o \fIXXXX\fB,\fIYYYY\fB,\fIZZZZ\fB\fR\fI ...\fR ] [ \fB-O\fR ] [ \fB-p \fIPART\fB\fR ] [ \fB-q\fR ] [ \fB-r\fR | \fB-y\fR ] [ \fB-t \fIseconds\fB\fR ] [ \fB-T\fR ] [ \fB-u\fR ] [ \fB-v\fR ] [ \fB-V\fR ] [ \fB-@ \fIfile\fB\fR ]
 
 .SH "DESCRIPTION"
 .PP
@@ -145,9 +145,6 @@ Verbose mode - prints additional information.
 .TP
 \fB-V | --version\fR
 Just print version string and exit.
-.TP
-\fB-w | --write-signature\fR
-Write unique signature to the MBR if needed.
 .TP
 \fB-y | --sysprep\fR
 Operate on SysPrep#### variables instead of Boot#### variables.

--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -1428,7 +1428,6 @@ usage()
 	printf("\t-u | --unicode | --UCS-2  Handle extra args as UCS-2 (default is ASCII).\n");
 	printf("\t-v | --verbose          Print additional information.\n");
 	printf("\t-V | --version          Return version and exit.\n");
-	printf("\t-w | --write-signature  Write unique sig to MBR if needed.\n");
 	printf("\t-y | --sysprep          Operate on SysPrep variables, not Boot Variables.\n");
 	printf("\t-@ | --append-binary-args file  Append extra args from file (use \"-\" for stdin).\n");
 	printf("\t-h | --help             Show help/usage.\n");
@@ -1501,7 +1500,6 @@ parse_opts(int argc, char **argv)
 			{"UCS-2",                  no_argument, 0, 'u'},
 			{"verbose",          optional_argument, 0, 'v'},
 			{"version",                no_argument, 0, 'V'},
-			{"write-signature",        no_argument, 0, 'w'},
 			{"sysprep",                no_argument, 0, 'y'},
 			{"append-binary-args", required_argument, 0, '@'},
 			{"help",                   no_argument, 0, 'h'},
@@ -1750,10 +1748,6 @@ parse_opts(int argc, char **argv)
 			break;
 		case 'V':
 			opts.showversion = 1;
-			break;
-
-		case 'w':
-			opts.write_signature = 1;
 			break;
 
 		case 'y':

--- a/src/include/efibootmgr.h
+++ b/src/include/efibootmgr.h
@@ -84,7 +84,6 @@ typedef struct {
 	unsigned int showversion:1;
 	unsigned int create:1;
 	unsigned int unicode:1;
-	unsigned int write_signature:1;
 	unsigned int forcegpt:1;
 	unsigned int set_timeout:1;
 	unsigned int delete_timeout:1;


### PR DESCRIPTION
According to https://github.com/rhboot/efibootmgr/issues/101, the --write-signature option does nothing. This change removes the option.