### PR TITLE
efibootmgr: delete_bootnext is just a boolean, not an entry id

### DIFF
--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -1927,10 +1927,6 @@ main(int argc, char **argv)
 	}
 
 	if (opts.delete_bootnext) {
-		if (!is_current_entry(opts.delete_bootnext))
-			errorx(17, "Boot entry %04X does not exist",
-				opts.delete_bootnext);
-
 		ret = efi_del_variable(EFI_GLOBAL_GUID, "BootNext");
 		if (ret < 0)
 			error(10, "Could not delete BootNext");


### PR DESCRIPTION
When deleting bootnext, there's nothing to validate (other than the variable existing, in which case del will fail as expected).

This appears to be a copy/paste error when adding the delete-bootnext option from the [create] bootnext option.