### PR TITLE
Use #pragma once in header files

### DIFF
--- a/src/error.h
+++ b/src/error.h
@@ -17,8 +17,8 @@
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
-#ifndef EFIBOOTMGR_ERROR_H__
-#define EFIBOOTMGR_ERROR_H__ 1
+
+#pragma once
 
 extern int verbose;
 
@@ -163,4 +163,3 @@ warningx(const char *fmt, ...)
 	conditional_error_reporter(verbose >= 1, 1);
 	va_end(ap);
 }
-#endif /* EFIBOOTMGR_ERROR_H__ */

--- a/src/fix_coverity.h
+++ b/src/fix_coverity.h
@@ -5,8 +5,7 @@
  * Distributed under terms of the GPLv3 license.
  */
 
-#ifndef FIX_COVERITY_H
-#define FIX_COVERITY_H
+#pragma once
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -90,5 +89,4 @@ typedef _Complex float __cfloat128 __attribute__ ((__mode__ (__TC__)));
 #undef __COVERITY_GCC_VERSION_AT_LEAST
 #endif
 
-#endif /* !FIX_COVERITY_H */
 // vim:fenc=utf-8:tw=75

--- a/src/include/efi.h
+++ b/src/include/efi.h
@@ -18,8 +18,7 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#ifndef EFI_H
-#define EFI_H
+#pragma once
 
 /*
  * Extensible Firmware Interface
@@ -69,5 +68,3 @@ typedef struct {
 
 #define ADDRESS_RANGE_MIRROR_VARIABLE_CURRENT "MirrorCurrent"
 #define ADDRESS_RANGE_MIRROR_VARIABLE_REQUEST "MirrorRequest"
-
-#endif /* EFI_H */

--- a/src/include/efibootmgr.h
+++ b/src/include/efibootmgr.h
@@ -18,8 +18,7 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#ifndef _EFIBOOTMGR_H
-#define _EFIBOOTMGR_H
+#pragma once
 
 #define EFIBOOTMGR_IPV4 0
 #define EFIBOOTMGR_IPV6 1
@@ -99,5 +98,3 @@ typedef struct {
 } efibootmgr_opt_t;
 
 extern efibootmgr_opt_t opts;
-
-#endif

--- a/src/include/list.h
+++ b/src/include/list.h
@@ -2,9 +2,7 @@
    Copied from the Linux 2.4.4 kernel, in linux/include/linux/list.h
 */
 
-#ifndef _LINUX_LIST_H
-#define _LINUX_LIST_H
-
+#pragma once
 
 /*
  * Simple doubly linked list implementation.
@@ -163,7 +161,3 @@ static __inline__ void list_splice(struct list_head *list, struct list_head *hea
 #define list_for_each_safe(pos, n, head) \
 	for (pos = (head)->next, n = pos->next; pos != (head); \
 		pos = n, n = pos->next)
-
-
-
-#endif

--- a/src/include/parse_loader_data.h
+++ b/src/include/parse_loader_data.h
@@ -17,8 +17,7 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#ifndef _PARSE_LOADER_DATA_H
-#define _PARSE_LOADER_DATA_H
+#pragma once
 
 #include <stdint.h>
 #include "efi.h"
@@ -27,5 +26,3 @@ ssize_t parse_efi_guid(char *buffer, size_t buffer_size,
 		       uint8_t *p, uint64_t length);
 ssize_t parse_raw_text(char *buffer, size_t buffer_size,
 		       uint8_t *p, uint64_t length);
-
-#endif


### PR DESCRIPTION
All compilers have supported this for at least the 5 years, some like gcc and clang much longer.