### PR TITLE
efibootmgr: clarify description of --unicode flag

### DIFF
--- a/README
+++ b/README
@@ -10,33 +10,42 @@ Note: efibootmgr requires either the efivarfs or the
 legacy efivars kernel module to be loaded prior to use.
 
 usage: efibootmgr [options]
-        -a | --active          Set bootnum active.
-        -A | --inactive        Set bootnum inactive.
-        -b | --bootnum XXXX    Modify BootXXXX (hex).
-        -B | --delete-bootnum  Delete bootnum.
-        -c | --create          Create new variable bootnum and add to bootorder.
-        -d | --disk disk       (Defaults to /dev/sda) containing loader.
-        -e | --edd [1|3|-1]    Force EDD 1.0 or 3.0 creation variables, or guess.
-        -E | --device num      EDD 1.0 device number (defaults to 0x80).
-        -f | --reconnect       Re-connect devices after driver is loaded.
-        -F | --no-reconnect    Do not re-connect devices after driver is loaded.
-        -g | --gpt             Force disk w/ invalid PMBR to be treated as GPT.
-        -i | --iface name      Create a netboot entry for the named interface.
-        -l | --loader name     (Defaults to \elilo.efi).
-        -L | --label label     Boot manager display label (defaults to "Linux").
-        -n | --bootnext XXXX   Set BootNext to XXXX (hex).
-        -N | --delete-bootnext Delete BootNext.
-        -o | --bootorder XXXX,YYYY,ZZZZ,...     Explicitly set BootOrder (hex).
-        -O | --delete-bootorder   Delete BootOrder.
-        -p | --part part          (Defaults to 1) containing loader.
-        -q | --quiet              Be quiet.
-        -t | --timeout seconds    Boot manager timeout.
-        -T | --delete-timeout     Delete Timeout value.
-        -u | --unicode | --UCS-2  Pass extra args as UCS-2 (default is ASCII).
-        -v | --verbose            Print additional information.
-        -V | --version            Return version and exit.
-        -@ | --append-binary-args Append extra variable args from
-                                  file (use - to read from stdin).
+	-a | --active         Set bootnum active.
+	-A | --inactive       Set bootnum inactive.
+	-b | --bootnum XXXX   Modify BootXXXX (hex).
+	-B | --delete-bootnum Delete bootnum.
+	-c | --create         Create new variable bootnum and add to bootorder at index (-I).
+	-C | --create-only    Create new variable bootnum and do not add to bootorder.
+	-d | --disk disk      Disk containing boot loader (defaults to /dev/sda).
+	-D | --remove-dups    Remove duplicate values from BootOrder.
+	-e | --edd [1|3]      Force boot entries to be created using EDD 1.0 or 3.0 info.
+	-E | --edd-device num     EDD 1.0 device number (defaults to 0x80).
+	    --full-dev-path  Use a full device path.
+	    --file-dev-path  Use an abbreviated File() device path.
+	-f | --reconnect      Re-connect devices after driver is loaded.
+	-F | --no-reconnect   Do not re-connect devices after driver is loaded.
+	-g | --gpt            Force disk with invalid PMBR to be treated as GPT.
+	-i | --iface name     Create a netboot entry for the named interface.
+	-I | --index number   When creating an entry, insert it in bootorder at specified position (default: 0).
+	-l | --loader name     (Defaults to "\EFI\fedora\grub.efi").
+	-L | --label label     Boot manager display label (defaults to "Linux").
+	-m | --mirror-below-4G t|f Mirror memory below 4GB.
+	-M | --mirror-above-4G X Percentage memory to mirror above 4GB.
+	-n | --bootnext XXXX   Set BootNext to XXXX (hex).
+	-N | --delete-bootnext Delete BootNext.
+	-o | --bootorder XXXX,YYYY,ZZZZ,...     Explicitly set BootOrder (hex).
+	-O | --delete-bootorder Delete BootOrder.
+	-p | --part part        Partition containing loader (defaults to 1 on partitioned devices).
+	-q | --quiet            Be quiet.
+	-r | --driver           Operate on Driver variables, not Boot Variables.
+	-t | --timeout seconds  Set boot manager timeout waiting for user input.
+	-T | --delete-timeout   Delete Timeout.
+	-u | --unicode | --UCS-2  Use UCS-2 encoding (instead of ASCII) to display/encode entry data.
+	-v | --verbose          Print additional information.
+	-V | --version          Return version and exit.
+	-y | --sysprep          Operate on SysPrep variables, not Boot Variables.
+	-@ | --append-binary-args file  Append extra args from file (use "-" for stdin).
+	-h | --help             Show help/usage.
 
 
 Typical usage:

--- a/README.md
+++ b/README.md
@@ -11,33 +11,42 @@ legacy efivars kernel module to be loaded prior to use.
 
 ```
 usage: efibootmgr [options]
-        -a | --active          Set bootnum active.
-        -A | --inactive        Set bootnum inactive.
-        -b | --bootnum XXXX    Modify BootXXXX (hex).
-        -B | --delete-bootnum  Delete bootnum.
-        -c | --create          Create new variable bootnum and add to bootorder.
-        -d | --disk disk       (Defaults to /dev/sda) containing loader.
-        -e | --edd [1|3|-1]    Force EDD 1.0 or 3.0 creation variables, or guess.
-        -E | --device num      EDD 1.0 device number (defaults to 0x80).
-        -f | --reconnect       Re-connect devices after driver is loaded.
-        -F | --no-reconnect    Do not re-connect devices after driver is loaded.
-        -g | --gpt             Force disk w/ invalid PMBR to be treated as GPT.
-        -i | --iface name      Create a netboot entry for the named interface.
-        -l | --loader name     (Defaults to \elilo.efi).
-        -L | --label label     Boot manager display label (defaults to "Linux").
-        -n | --bootnext XXXX   Set BootNext to XXXX (hex).
-        -N | --delete-bootnext Delete BootNext.
-        -o | --bootorder XXXX,YYYY,ZZZZ,...     Explicitly set BootOrder (hex).
-        -O | --delete-bootorder   Delete BootOrder.
-        -p | --part part          (Defaults to 1) containing loader.
-        -q | --quiet              Be quiet.
-        -t | --timeout seconds    Boot manager timeout.
-        -T | --delete-timeout     Delete Timeout value.
-        -u | --unicode | --UCS-2  Pass extra args as UCS-2 (default is ASCII).
-        -v | --verbose            Print additional information.
-        -V | --version            Return version and exit.
-        -@ | --append-binary-args Append extra variable args from
-                                  file (use - to read from stdin).
+	-a | --active         Set bootnum active.
+	-A | --inactive       Set bootnum inactive.
+	-b | --bootnum XXXX   Modify BootXXXX (hex).
+	-B | --delete-bootnum Delete bootnum.
+	-c | --create         Create new variable bootnum and add to bootorder at index (-I).
+	-C | --create-only    Create new variable bootnum and do not add to bootorder.
+	-d | --disk disk      Disk containing boot loader (defaults to /dev/sda).
+	-D | --remove-dups    Remove duplicate values from BootOrder.
+	-e | --edd [1|3]      Force boot entries to be created using EDD 1.0 or 3.0 info.
+	-E | --edd-device num     EDD 1.0 device number (defaults to 0x80).
+	    --full-dev-path  Use a full device path.
+	    --file-dev-path  Use an abbreviated File() device path.
+	-f | --reconnect      Re-connect devices after driver is loaded.
+	-F | --no-reconnect   Do not re-connect devices after driver is loaded.
+	-g | --gpt            Force disk with invalid PMBR to be treated as GPT.
+	-i | --iface name     Create a netboot entry for the named interface.
+	-I | --index number   When creating an entry, insert it in bootorder at specified position (default: 0).
+	-l | --loader name     (Defaults to "\EFI\fedora\grub.efi").
+	-L | --label label     Boot manager display label (defaults to "Linux").
+	-m | --mirror-below-4G t|f Mirror memory below 4GB.
+	-M | --mirror-above-4G X Percentage memory to mirror above 4GB.
+	-n | --bootnext XXXX   Set BootNext to XXXX (hex).
+	-N | --delete-bootnext Delete BootNext.
+	-o | --bootorder XXXX,YYYY,ZZZZ,...     Explicitly set BootOrder (hex).
+	-O | --delete-bootorder Delete BootOrder.
+	-p | --part part        Partition containing loader (defaults to 1 on partitioned devices).
+	-q | --quiet            Be quiet.
+	-r | --driver           Operate on Driver variables, not Boot Variables.
+	-t | --timeout seconds  Set boot manager timeout waiting for user input.
+	-T | --delete-timeout   Delete Timeout.
+	-u | --unicode | --UCS-2  Use UCS-2 encoding (instead of ASCII) to display/encode entry data.
+	-v | --verbose          Print additional information.
+	-V | --version          Return version and exit.
+	-y | --sysprep          Operate on SysPrep variables, not Boot Variables.
+	-@ | --append-binary-args file  Append extra args from file (use "-" for stdin).
+	-h | --help             Show help/usage.
 ```
 
 Typical usage:

--- a/src/efibootmgr.8.in
+++ b/src/efibootmgr.8.in
@@ -142,8 +142,7 @@ Boot Manager timeout, in \fIseconds\fR\&.
 Delete Timeout variable.
 .TP
 \fB-u | --unicode | --UCS-2 \fR
-Handle extra command line arguments as UCS-2 (default is
-ASCII).
+Use UCS-2 encoding (instead of ASCII) to display/encode entry data.
 .TP
 \fB-v | --verbose\fR
 Verbose mode - prints additional information.

--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -1480,7 +1480,7 @@ usage()
 	printf("\t-r | --driver           Operate on Driver variables, not Boot Variables.\n");
 	printf("\t-t | --timeout seconds  Set boot manager timeout waiting for user input.\n");
 	printf("\t-T | --delete-timeout   Delete Timeout.\n");
-	printf("\t-u | --unicode | --UCS-2  Handle extra args as UCS-2 (default is ASCII).\n");
+	printf("\t-u | --unicode | --UCS-2  Use UCS-2 encoding (instead of ASCII) to display/encode entry data.\n");
 	printf("\t-v | --verbose          Print additional information.\n");
 	printf("\t-V | --version          Return version and exit.\n");
 	printf("\t-y | --sysprep          Operate on SysPrep variables, not Boot Variables.\n");

--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -1078,7 +1078,7 @@ show_var_path(efi_load_option *load_option, size_t boot_data_size)
 		rc = parser(text_path, text_path_len,
 			    optional_data, optional_data_len);
 		if (rc < 0) {
-			warning("Could not parse device path");
+			warning("Could not parse optional data");
 			free(text_path);
 			return;
 		}
@@ -1923,7 +1923,7 @@ main(int argc, char **argv)
 	if (opts.active >= 0) {
 		if (opts.num == -1) {
 			errorx(4,
-			       "You must specify a entry to activate (see the -b option)");
+			       "You must specify an entry to activate (see the -b option)");
 		} else {
 			ret = set_active_state(prefices[mode]);
 			if (ret < 0)


### PR DESCRIPTION
The `--unicode` (aka `--UCS-2`) option enables not only encoding of command line args in UCS-2, but also decoding of them when reading and showing boot entries.

Update the description of this flag accordingly, both in the man page and in the usage message for `efibootmgr`.

Update `README` and `README.md` to have up-to-date `--help` output (it was quite far behind the current version).

Also, a couple of small fixes to error messages.