### PR TITLE
efibootmgr: Make the default output cleaner

### DIFF
--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -1139,8 +1139,11 @@ show_vars(const char *prefix)
 		printf("%c ", (efi_loadopt_attrs(load_option)
 			       & LOAD_OPTION_ACTIVE) ? '*' : ' ');
 		printf("%s", description);
-
-		show_var_path(load_option, boot->data_size);
+		if(opts.verbose || opts.unicode) {
+			show_var_path(load_option, boot->data_size);
+		} else {
+			printf("\n");
+		}
 
 		fflush(stdout);
 	}


### PR DESCRIPTION
Make the default output cleaner

If you bring device information, some boot options will be displayed too much and affect the experience.